### PR TITLE
feat:Update openapi.yaml to clarify streaming URL under urls; deprecate url

### DIFF
--- a/src/libs/Replicate/Generated/Replicate.IReplicateApi.DeploymentsPredictionsCreate.g.cs
+++ b/src/libs/Replicate/Generated/Replicate.IReplicateApi.DeploymentsPredictionsCreate.g.cs
@@ -67,7 +67,7 @@ namespace Replicate
         /// <param name="stream">
         /// **This field is deprecated.**<br/>
         /// Request a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).<br/>
-        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.
+        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.
         /// </param>
         /// <param name="webhook">
         /// An HTTPS URL for receiving a webhook when the prediction has new output. The webhook will be a POST request where the request body is the same as the response body of the [get prediction](#predictions.get) operation. If there are network problems, we will retry the webhook a few times, so make sure it can be safely called more than once. Replicate will not follow redirects when sending webhook requests to your service, so be sure to specify a URL that will resolve without redirecting.<br/>

--- a/src/libs/Replicate/Generated/Replicate.IReplicateApi.ModelsPredictionsCreate.g.cs
+++ b/src/libs/Replicate/Generated/Replicate.IReplicateApi.ModelsPredictionsCreate.g.cs
@@ -69,7 +69,7 @@ namespace Replicate
         /// <param name="stream">
         /// **This field is deprecated.**<br/>
         /// Request a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).<br/>
-        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.
+        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.
         /// </param>
         /// <param name="webhook">
         /// An HTTPS URL for receiving a webhook when the prediction has new output. The webhook will be a POST request where the request body is the same as the response body of the [get prediction](#predictions.get) operation. If there are network problems, we will retry the webhook a few times, so make sure it can be safely called more than once. Replicate will not follow redirects when sending webhook requests to your service, so be sure to specify a URL that will resolve without redirecting.<br/>

--- a/src/libs/Replicate/Generated/Replicate.IReplicateApi.PredictionsCreate.g.cs
+++ b/src/libs/Replicate/Generated/Replicate.IReplicateApi.PredictionsCreate.g.cs
@@ -61,7 +61,7 @@ namespace Replicate
         /// <param name="stream">
         /// **This field is deprecated.**<br/>
         /// Request a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).<br/>
-        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.
+        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.
         /// </param>
         /// <param name="version">
         /// The identifier for the model or model version that you want to run. This can be specified in a few different formats:<br/>

--- a/src/libs/Replicate/Generated/Replicate.Models.SchemasPredictionRequest.g.cs
+++ b/src/libs/Replicate/Generated/Replicate.Models.SchemasPredictionRequest.g.cs
@@ -27,7 +27,7 @@ namespace Replicate
         /// <summary>
         /// **This field is deprecated.**<br/>
         /// Request a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).<br/>
-        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.
+        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("stream")]
         public bool? Stream { get; set; }
@@ -87,7 +87,7 @@ namespace Replicate
         /// <param name="stream">
         /// **This field is deprecated.**<br/>
         /// Request a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).<br/>
-        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.
+        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.
         /// </param>
         /// <param name="webhook">
         /// An HTTPS URL for receiving a webhook when the prediction has new output. The webhook will be a POST request where the request body is the same as the response body of the [get prediction](#predictions.get) operation. If there are network problems, we will retry the webhook a few times, so make sure it can be safely called more than once. Replicate will not follow redirects when sending webhook requests to your service, so be sure to specify a URL that will resolve without redirecting.<br/>

--- a/src/libs/Replicate/Generated/Replicate.Models.SchemasVersionPredictionRequest.g.cs
+++ b/src/libs/Replicate/Generated/Replicate.Models.SchemasVersionPredictionRequest.g.cs
@@ -27,7 +27,7 @@ namespace Replicate
         /// <summary>
         /// **This field is deprecated.**<br/>
         /// Request a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).<br/>
-        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.
+        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("stream")]
         public bool? Stream { get; set; }
@@ -100,7 +100,7 @@ namespace Replicate
         /// <param name="stream">
         /// **This field is deprecated.**<br/>
         /// Request a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).<br/>
-        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.
+        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.
         /// </param>
         /// <param name="version">
         /// The identifier for the model or model version that you want to run. This can be specified in a few different formats:<br/>

--- a/src/libs/Replicate/Generated/Replicate.ReplicateApi.DeploymentsPredictionsCreate.g.cs
+++ b/src/libs/Replicate/Generated/Replicate.ReplicateApi.DeploymentsPredictionsCreate.g.cs
@@ -236,7 +236,7 @@ namespace Replicate
         /// <param name="stream">
         /// **This field is deprecated.**<br/>
         /// Request a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).<br/>
-        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.
+        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.
         /// </param>
         /// <param name="webhook">
         /// An HTTPS URL for receiving a webhook when the prediction has new output. The webhook will be a POST request where the request body is the same as the response body of the [get prediction](#predictions.get) operation. If there are network problems, we will retry the webhook a few times, so make sure it can be safely called more than once. Replicate will not follow redirects when sending webhook requests to your service, so be sure to specify a URL that will resolve without redirecting.<br/>

--- a/src/libs/Replicate/Generated/Replicate.ReplicateApi.ModelsPredictionsCreate.g.cs
+++ b/src/libs/Replicate/Generated/Replicate.ReplicateApi.ModelsPredictionsCreate.g.cs
@@ -238,7 +238,7 @@ namespace Replicate
         /// <param name="stream">
         /// **This field is deprecated.**<br/>
         /// Request a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).<br/>
-        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.
+        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.
         /// </param>
         /// <param name="webhook">
         /// An HTTPS URL for receiving a webhook when the prediction has new output. The webhook will be a POST request where the request body is the same as the response body of the [get prediction](#predictions.get) operation. If there are network problems, we will retry the webhook a few times, so make sure it can be safely called more than once. Replicate will not follow redirects when sending webhook requests to your service, so be sure to specify a URL that will resolve without redirecting.<br/>

--- a/src/libs/Replicate/Generated/Replicate.ReplicateApi.PredictionsCreate.g.cs
+++ b/src/libs/Replicate/Generated/Replicate.ReplicateApi.PredictionsCreate.g.cs
@@ -222,7 +222,7 @@ namespace Replicate
         /// <param name="stream">
         /// **This field is deprecated.**<br/>
         /// Request a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).<br/>
-        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.
+        /// This field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.
         /// </param>
         /// <param name="version">
         /// The identifier for the model or model version that you want to run. This can be specified in a few different formats:<br/>

--- a/src/libs/Replicate/openapi.yaml
+++ b/src/libs/Replicate/openapi.yaml
@@ -1377,7 +1377,7 @@ components:
             system_prompt: You are a helpful assistant
         stream:
           type: boolean
-          description: "**This field is deprecated.**\n\nRequest a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).\n\nThis field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.\n"
+          description: "**This field is deprecated.**\n\nRequest a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).\n\nThis field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.\n"
         webhook:
           type: string
           description: "An HTTPS URL for receiving a webhook when the prediction has new output. The webhook will be a POST request where the request body is the same as the response body of the [get prediction](#predictions.get) operation. If there are network problems, we will retry the webhook a few times, so make sure it can be safely called more than once. Replicate will not follow redirects when sending webhook requests to your service, so be sure to specify a URL that will resolve without redirecting.\n"
@@ -1677,7 +1677,7 @@ components:
             text: Alice
         stream:
           type: boolean
-          description: "**This field is deprecated.**\n\nRequest a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).\n\nThis field is no longer needed as the returned prediction will always have a `stream` entry in its `url` property if the model supports streaming.\n"
+          description: "**This field is deprecated.**\n\nRequest a URL to receive streaming output using [server-sent events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).\n\nThis field is no longer needed as the returned prediction will always have a `stream` entry in its `urls` property if the model supports streaming.\n"
         version:
           type: string
           description: "The identifier for the model or model version that you want to run. This can be specified in a few different formats:\n\n- `{owner_name}/{model_name}` - Use this format for [official models](https://replicate.com/docs/topics/models/official-models). For example, `black-forest-labs/flux-schnell`. For all other models, the specific version is required.\n- `{owner_name}/{model_name}:{version_id}` - The owner and model name, plus the full 64-character version ID. For example, `replicate/hello-world:9dcd6d78e7c6560c340d916fe32e9f24aabfa331e5cce95fe31f77fb03121426`.\n- `{version_id}` - Just the 64-character version ID. For example, `9dcd6d78e7c6560c340d916fe32e9f24aabfa331e5cce95fe31f77fb03121426`\n"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Corrected API reference for the stream field to point to the streaming URL under urls (instead of url) in prediction responses.
  - Clarified the deprecation notice to reflect the correct property path.
  - Improves accuracy of integration guidance; no functional or behavioral changes to the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->